### PR TITLE
safariでQuestionが改行されないように

### DIFF
--- a/components/edit/ListTitle.tsx
+++ b/components/edit/ListTitle.tsx
@@ -10,35 +10,16 @@ import {Box, Text, ChakraProps} from '@chakra-ui/react';
 import React from 'react';
 
 const ListTitle = React.memo<{type: string} & ChakraProps>(props => {
-  switch (props.type) {
-    case 'quiz':
-      return (
-        <Box fontWeight="bold" fontSize="1.5rem" width="140px" {...props}>
-          <Text as="span" fontSize="2.7rem" marginRight=".25rem">
-            Q
-          </Text>
-          uiz
-        </Box>
-      );
-    case 'question':
-      return (
-        <Box fontWeight="bold" fontSize="1.5rem" width="140px" {...props}>
-          <Text as="span" fontSize="2.7rem" marginRight=".25rem">
-            Q
-          </Text>
-          usestion
-        </Box>
-      );
-    default:
-      return (
-        <Box fontWeight="bold" fontSize="1.5rem" width="140px" {...props}>
-          <Text as="span" fontSize="2.7rem" marginRight=".25rem">
-            O
-          </Text>
-          ops!
-        </Box>
-      );
-  }
+  return (
+    <Box fontWeight="bold" fontSize="1.5rem" width="140px" {...props}>
+      <Text as="span" fontSize="2.7rem" marginRight=".25rem">
+        {props.type.slice(0, 1).toUpperCase()}
+      </Text>
+      <Text as="span" fontSize="1.5rem" wordBreak="keep-all">
+        {props.type.slice(1).toLowerCase()}
+      </Text>
+    </Box>
+  );
 });
 
 ListTitle.displayName = 'listTitle';


### PR DESCRIPTION
## やったこと

safariでQuestionが改行されてしまう問題を解消しました。

## スクショ

|before|after|
|---|---|
|<img width="1027" alt="スクリーンショット 2021-08-28 23 01 48" src="https://user-images.githubusercontent.com/44374005/131220489-6fce8e01-0840-4c4d-9e3c-0e9f056496ba.png">|<img width="980" alt="スクリーンショット 2021-08-28 23 02 17" src="https://user-images.githubusercontent.com/44374005/131220494-4c9d1f4d-ec5b-43f9-bfd3-c34bd9c5a27d.png">|

## issue

#106 