### PR TITLE
Fix/details bug

### DIFF
--- a/components/show/contents/question/Qustion.tsx
+++ b/components/show/contents/question/Qustion.tsx
@@ -14,7 +14,7 @@ import Design from '../common/Design';
 
 const Question: React.FC<{id: string}> = ({id}) => {
   const slideshowData = useRecoilValue(SlideshowDataState);
-  const questionData = slideshowData.data.find(value => value.key === id)
+  const questionData = slideshowData.data?.find(value => value.key === id)
     .value as QuestionType;
 
   return (

--- a/components/show/contents/quiz/QuizFirst.tsx
+++ b/components/show/contents/quiz/QuizFirst.tsx
@@ -14,13 +14,13 @@ import Design from '../common/Design';
 
 const QuizFirst: React.FC<{id: string}> = ({id}) => {
   const slideshowData = useRecoilValue(SlideshowDataState);
-  const questionData = slideshowData.data.find(value => value.key === id)
+  const questionData = slideshowData.data?.find(value => value.key === id)
     .value as Quiz;
 
   return (
     <Design data={questionData?.slideDesign}>
       <Center paddingY="2rem">
-        <Heading fontSize="4rem">{questionData.title || '？'}</Heading>
+        <Heading fontSize="4rem">{questionData?.title || '？'}</Heading>
       </Center>
     </Design>
   );

--- a/components/show/contents/quiz/QuizSecond.tsx
+++ b/components/show/contents/quiz/QuizSecond.tsx
@@ -14,7 +14,7 @@ import Design from '../common/Design';
 
 const QuizSecond: React.FC<{id: string}> = ({id}) => {
   const slideshowData = useRecoilValue(SlideshowDataState);
-  const questionData = slideshowData.data.find(value => value.key === id)
+  const questionData = slideshowData.data?.find(value => value.key === id)
     .value as Quiz;
 
   return (
@@ -29,7 +29,7 @@ const QuizSecond: React.FC<{id: string}> = ({id}) => {
           正解は
         </Heading>
         <Heading fontSize="6rem">
-          {questionData.choices[questionData.answerIndex].text || '？'}
+          {questionData?.choices[questionData?.answerIndex].text || '？'}
         </Heading>
       </Flex>
     </Design>

--- a/documents/debug.md
+++ b/documents/debug.md
@@ -1,18 +1,23 @@
 # デバッグ方法
 
-- デバッグ用ドメイン: `hello-slide.net`
+- ~~デバッグ用ドメイン: `hello-slide.net`~~
+- デバッグ用ドメイン: `hello-slide.jp`
 
 ## 1. 環境変数設定
 
 ```env
-NEXT_PUBLIC_API_DOMAIN=api.hello-slide.net
-NEXT_PUBLIC_DOMAIN=hello-slide.net
+NEXT_PUBLIC_API_DOMAIN=api.hello-slide.jp
+NEXT_PUBLIC_DOMAIN=hello-slide.jp
 ```
 
 ## 2. hostsファイル変更
 
 ```bash
+# debian linux
 sudo vi /etc/hosts
+
+# mac
+sudo vi /private/etc/hosts
 ```
 
 ```text

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -21,7 +21,13 @@ const Dashboard = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  if (cookie(context.req.headers.cookie, ['session_token'], false)) {
+  if (
+    cookie(
+      context.req.headers.cookie,
+      ['session_token', 'refresh_token'],
+      false
+    )
+  ) {
     return {
       redirect: {
         statusCode: 301,

--- a/pages/edit/[id].tsx
+++ b/pages/edit/[id].tsx
@@ -24,7 +24,13 @@ const Edit = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  if (cookie(context.req.headers.cookie, ['session_token'], false)) {
+  if (
+    cookie(
+      context.req.headers.cookie,
+      ['session_token', 'refresh_token'],
+      false
+    )
+  ) {
     return {
       redirect: {
         statusCode: 301,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,9 @@ const Index = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  if (cookie(context.req.headers.cookie, ['session_token'], true)) {
+  if (
+    cookie(context.req.headers.cookie, ['session_token', 'refresh_token'], true)
+  ) {
     return {
       redirect: {
         statusCode: 301,

--- a/pages/setting.tsx
+++ b/pages/setting.tsx
@@ -21,7 +21,13 @@ const Setting = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async context => {
-  if (cookie(context.req.headers.cookie, ['session_token'], false)) {
+  if (
+    cookie(
+      context.req.headers.cookie,
+      ['session_token', 'refresh_token'],
+      false
+    )
+  ) {
     return {
       redirect: {
         statusCode: 301,

--- a/utils/cookie/cookie.ts
+++ b/utils/cookie/cookie.ts
@@ -36,17 +36,14 @@ export default function cookie(
     }
 
     if (keys.includes(key)) {
-      if (!isExist && !value) {
-        return true;
+      if (!isExist && value) {
+        // exist
+        return false;
       } else if (isExist && value) {
         keysLength++;
       }
     }
   }
 
-  if (isExist) {
-    return keys.length === keysLength;
-  }
-
-  return true;
+  return (keys.length === keysLength) === isExist;
 }

--- a/utils/cookie/cookie.ts
+++ b/utils/cookie/cookie.ts
@@ -37,12 +37,16 @@ export default function cookie(
 
     if (keys.includes(key)) {
       if (!isExist && !value) {
-        return false;
+        return true;
       } else if (isExist && value) {
         keysLength++;
       }
     }
   }
 
-  return keys.length === keysLength;
+  if (isExist) {
+    return keys.length === keysLength;
+  }
+
+  return true;
 }


### PR DESCRIPTION
## ページを作成し編集しない状態でプレゼンテーションを開始した場合エラーが発生する問題を修正

- resolved https://github.com/hello-slide/front/issues/122

## ログインしていないときに`/dashboard`、`/setting`、`/edit`にアクセスするとリダイレクトされない問題を修正

がんばった

## ドキュメント追加: デバッグ時のドメインを変更

`hello-slide.net` -> `hello-slide.jp`

APIに.netドメインのk8sクラスタを動かしていたがGKEの管理手数料（1個分クラスタは無料）（2個目移行は月8000円取られる…）が思ったよりかかるため削除し、本番環境と同じAPIを使用することにした。

## ドキュメント追加: hostsファイルの設定方法にmacを追加
